### PR TITLE
Add /dcrbtnreset command and document button slash commands

### DIFF
--- a/Decursive.lua
+++ b/Decursive.lua
@@ -2855,5 +2855,3 @@ function Dcr_Cast_CureSpell( spellID, Unit, AfflictionType, ClearCurrentTarget) 
 end --}}}
 -- }}}
 -------------------------------------------------------------------------------
-
-

--- a/Decursive.toc
+++ b/Decursive.toc
@@ -10,6 +10,7 @@ localization.lua
 localization.fr.lua
 localization.de.lua
 localization.tw.lua
+localization.es.lua
 DecursiveButton.lua
 Decursive.lua
 Decursive.xml

--- a/Decursive.toc
+++ b/Decursive.toc
@@ -10,5 +10,6 @@ localization.lua
 localization.fr.lua
 localization.de.lua
 localization.tw.lua
+DecursiveButton.lua
 Decursive.lua
 Decursive.xml

--- a/DecursiveButton.lua
+++ b/DecursiveButton.lua
@@ -1,0 +1,15 @@
+-- DecursiveButton.lua
+DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00Decursive Button loaded:|r Click to decurse, drag to move.")
+
+DecursiveCustomButton = CreateFrame("Button", "DecursiveCustomButton", UIParent)
+DecursiveCustomButton:SetWidth(44)
+DecursiveCustomButton:SetHeight(44)
+DecursiveCustomButton:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
+DecursiveCustomButton:SetMovable(true)
+DecursiveCustomButton:EnableMouse(true)
+DecursiveCustomButton:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+DecursiveCustomButton:RegisterForDrag("LeftButton")
+DecursiveCustomButton:SetScript("OnDragStart", function() this:StartMoving() end)
+DecursiveCustomButton:SetScript("OnDragStop", function() this:StopMovingOrSizing() end)
+DecursiveCustomButton:SetNormalTexture("Interface\\Icons\\Ability_Creature_Disease_02")
+DecursiveCustomButton:SetScript("OnClick", function() SlashCmdList["DECURSIVE"]("") end)

--- a/DecursiveButton.lua
+++ b/DecursiveButton.lua
@@ -1,9 +1,32 @@
 -- DecursiveButton.lua
-DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00Decursive Button loaded:|r Click to decurse, drag to move.")
+DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00Decursive Button loaded:|r Click to decurse, drag to move, Shift+Scroll to resize, Shift+RightClick to change icon.")
+
+-- Default button settings
+local DCR_BUTTON_DEFAULT_SIZE = 44
+local DCR_BUTTON_MIN_SIZE = 20
+local DCR_BUTTON_MAX_SIZE = 100
+local DCR_BUTTON_SIZE_STEP = 4
+
+-- Available icons for the button
+local DCR_BUTTON_ICONS = {
+    "Interface\\Icons\\Ability_Creature_Disease_02",
+    "Interface\\Icons\\Spell_Holy_RemoveCurse",
+    "Interface\\Icons\\Spell_Nature_RemoveCurse",
+    "Interface\\Icons\\Spell_Nature_NullifyPoison",
+    "Interface\\Icons\\Spell_Holy_DispelMagic",
+    "Interface\\Icons\\Spell_Nature_Purge",
+    "Interface\\Icons\\Spell_Holy_Restoration",
+    "Interface\\Icons\\Spell_Nature_Abolishmagic",
+    "Interface\\Icons\\Spell_Holy_SealOfWrath",
+    "Interface\\Icons\\Spell_Nature_SlowPoison",
+    "Interface\\Icons\\Spell_Holy_Cleanse",
+    "Interface\\Icons\\Spell_Nature_NullifyDisease",
+}
+local DCR_BUTTON_DEFAULT_ICON = 1
 
 DecursiveCustomButton = CreateFrame("Button", "DecursiveCustomButton", UIParent)
-DecursiveCustomButton:SetWidth(44)
-DecursiveCustomButton:SetHeight(44)
+DecursiveCustomButton:SetWidth(DCR_BUTTON_DEFAULT_SIZE)
+DecursiveCustomButton:SetHeight(DCR_BUTTON_DEFAULT_SIZE)
 DecursiveCustomButton:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
 DecursiveCustomButton:SetMovable(true)
 DecursiveCustomButton:EnableMouse(true)
@@ -11,5 +34,108 @@ DecursiveCustomButton:RegisterForClicks("LeftButtonUp", "RightButtonUp")
 DecursiveCustomButton:RegisterForDrag("LeftButton")
 DecursiveCustomButton:SetScript("OnDragStart", function() this:StartMoving() end)
 DecursiveCustomButton:SetScript("OnDragStop", function() this:StopMovingOrSizing() end)
-DecursiveCustomButton:SetNormalTexture("Interface\\Icons\\Ability_Creature_Disease_02")
-DecursiveCustomButton:SetScript("OnClick", function() SlashCmdList["DECURSIVE"]("") end)
+DecursiveCustomButton:SetNormalTexture(DCR_BUTTON_ICONS[DCR_BUTTON_DEFAULT_ICON])
+
+-- Handle click events
+DecursiveCustomButton:SetScript("OnClick", function()
+    if arg1 == "RightButton" and IsShiftKeyDown() then
+        -- Cycle to next icon
+        local currentIndex = 1
+        if Dcr_Saved and Dcr_Saved.ButtonIcon then
+            currentIndex = Dcr_Saved.ButtonIcon
+        end
+        currentIndex = currentIndex + 1
+        if currentIndex > table.getn(DCR_BUTTON_ICONS) then
+            currentIndex = 1
+        end
+        DecursiveCustomButton:SetNormalTexture(DCR_BUTTON_ICONS[currentIndex])
+        if Dcr_Saved then
+            Dcr_Saved.ButtonIcon = currentIndex
+        end
+    else
+        SlashCmdList["DECURSIVE"]("")
+    end
+end)
+
+-- Enable mouse wheel for resizing
+DecursiveCustomButton:EnableMouseWheel(true)
+DecursiveCustomButton:SetScript("OnMouseWheel", function()
+    if IsShiftKeyDown() then
+        local currentSize = this:GetWidth()
+        local newSize
+        if arg1 > 0 then
+            newSize = math.min(currentSize + DCR_BUTTON_SIZE_STEP, DCR_BUTTON_MAX_SIZE)
+        else
+            newSize = math.max(currentSize - DCR_BUTTON_SIZE_STEP, DCR_BUTTON_MIN_SIZE)
+        end
+        this:SetWidth(newSize)
+        this:SetHeight(newSize)
+        -- Save the size
+        if Dcr_Saved then
+            Dcr_Saved.ButtonSize = newSize
+        end
+    end
+end)
+
+-- Function to apply saved button size
+function DecursiveCustomButton_ApplySavedSize()
+    if Dcr_Saved and Dcr_Saved.ButtonSize then
+        local size = Dcr_Saved.ButtonSize
+        DecursiveCustomButton:SetWidth(size)
+        DecursiveCustomButton:SetHeight(size)
+    end
+end
+
+-- Function to apply saved button icon
+function DecursiveCustomButton_ApplySavedIcon()
+    if Dcr_Saved and Dcr_Saved.ButtonIcon then
+        local iconIndex = Dcr_Saved.ButtonIcon
+        if iconIndex >= 1 and iconIndex <= table.getn(DCR_BUTTON_ICONS) then
+            DecursiveCustomButton:SetNormalTexture(DCR_BUTTON_ICONS[iconIndex])
+        end
+    end
+end
+
+-- Slash command to resize button: /dcrsize <size>
+SLASH_DECURSIVESIZE1 = "/dcrsize"
+SlashCmdList["DECURSIVESIZE"] = function(msg)
+    local size = tonumber(msg)
+    if size then
+        size = math.max(DCR_BUTTON_MIN_SIZE, math.min(size, DCR_BUTTON_MAX_SIZE))
+        DecursiveCustomButton:SetWidth(size)
+        DecursiveCustomButton:SetHeight(size)
+        if Dcr_Saved then
+            Dcr_Saved.ButtonSize = size
+        end
+        DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00Decursive Button size set to:|r " .. size .. "px")
+    else
+        DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00Decursive Button:|r Current size is " .. DecursiveCustomButton:GetWidth() .. "px")
+        DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00Usage:|r /dcrsize <size> (min: " .. DCR_BUTTON_MIN_SIZE .. ", max: " .. DCR_BUTTON_MAX_SIZE .. ")")
+        DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00Tip:|r Hold Shift + Mouse Wheel to resize interactively")
+    end
+end
+
+-- Slash command to change icon: /dcricon <number>
+SLASH_DECURSIVEICON1 = "/dcricon"
+SlashCmdList["DECURSIVEICON"] = function(msg)
+    local iconIndex = tonumber(msg)
+    if iconIndex and iconIndex >= 1 and iconIndex <= table.getn(DCR_BUTTON_ICONS) then
+        DecursiveCustomButton:SetNormalTexture(DCR_BUTTON_ICONS[iconIndex])
+        if Dcr_Saved then
+            Dcr_Saved.ButtonIcon = iconIndex
+        end
+        DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00Decursive Button icon set to:|r #" .. iconIndex)
+    else
+        DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00Decursive Button:|r Available icons (1-" .. table.getn(DCR_BUTTON_ICONS) .. ")")
+        DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00Usage:|r /dcricon <number>")
+        DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00Tip:|r Shift + Right Click to cycle through icons")
+    end
+end
+
+-- Register for VARIABLES_LOADED to restore saved settings
+local sizeLoader = CreateFrame("Frame")
+sizeLoader:RegisterEvent("VARIABLES_LOADED")
+sizeLoader:SetScript("OnEvent", function()
+    DecursiveCustomButton_ApplySavedSize()
+    DecursiveCustomButton_ApplySavedIcon()
+end)

--- a/DecursiveButton.lua
+++ b/DecursiveButton.lua
@@ -132,6 +132,25 @@ SlashCmdList["DECURSIVEICON"] = function(msg)
     end
 end
 
+-- Slash command to reset button: /dcrbtnreset
+SLASH_DECURSIVEBTNRESET1 = "/dcrbtnreset"
+SlashCmdList["DECURSIVEBTNRESET"] = function(msg)
+    -- Reset size to default
+    DecursiveCustomButton:SetWidth(DCR_BUTTON_DEFAULT_SIZE)
+    DecursiveCustomButton:SetHeight(DCR_BUTTON_DEFAULT_SIZE)
+    -- Reset icon to default
+    DecursiveCustomButton:SetNormalTexture(DCR_BUTTON_ICONS[DCR_BUTTON_DEFAULT_ICON])
+    -- Reset position to center
+    DecursiveCustomButton:ClearAllPoints()
+    DecursiveCustomButton:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
+    -- Update saved variables
+    if Dcr_Saved then
+        Dcr_Saved.ButtonSize = DCR_BUTTON_DEFAULT_SIZE
+        Dcr_Saved.ButtonIcon = DCR_BUTTON_DEFAULT_ICON
+    end
+    DEFAULT_CHAT_FRAME:AddMessage("|cff00ff00Decursive Button reset:|r Size " .. DCR_BUTTON_DEFAULT_SIZE .. "px, Icon #" .. DCR_BUTTON_DEFAULT_ICON .. ", centered.")
+end
+
 -- Register for VARIABLES_LOADED to restore saved settings
 local sizeLoader = CreateFrame("Frame")
 sizeLoader:RegisterEvent("VARIABLES_LOADED")

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This fork adds a **draggable button** that lets you trigger Decursive with a sin
 - **Drag** the button to move it anywhere on screen
 
 The button loads automatically and shows an icon in the center of your screen.
+Now localized in SPANISH
 
 ---
 
-*Forked from [MarcelineVQ/Decursive](https://github.com/MarcelineVQ/Decursive)*
+*Forked from [MarcelineVQ/Decursive](https://github.com/MarcelineVQ/Decursive)* by Antonio Pérez

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Decursive (Fork with Button)
+
+A raid cleansing addon for WoW 1.12 / TurtleWoW.
+
+## New Feature: Decursive Button
+
+This fork adds a **draggable button** that lets you trigger Decursive with a single click.
+
+- **Click** the button to decurse
+- **Drag** the button to move it anywhere on screen
+
+The button loads automatically and shows an icon in the center of your screen.
+
+---
+
+*Forked from [MarcelineVQ/Decursive](https://github.com/MarcelineVQ/Decursive)*

--- a/README.md
+++ b/README.md
@@ -8,9 +8,19 @@ This fork adds a **draggable button** that lets you trigger Decursive with a sin
 
 - **Click** the button to decurse
 - **Drag** the button to move it anywhere on screen
+- **Shift + Mouse Wheel** to resize interactively
+- **Shift + Right Click** to cycle through icons
 
 The button loads automatically and shows an icon in the center of your screen.
 Now localized in SPANISH
+
+## Slash Commands (Button)
+
+| Command | Description |
+|---------|-------------|
+| `/dcrsize <size>` | Set button size in pixels (min: 20, max: 100). Without argument shows current size. |
+| `/dcricon <number>` | Change button icon (1-12). Without argument shows available icons. |
+| `/dcrbtnreset` | Reset button to default. |
 
 ---
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -53,6 +53,16 @@ COMMANDS YOU CAN USE:
 /dcrdebug
 ---> Display Debug information
 
+BUTTON COMMANDS (new in this fork):
+/dcrsize <size>
+---> Set the Decursive button size in pixels (min: 20, max: 100). Without argument shows current size.
+/dcricon <number>
+---> Change the Decursive button icon (1-12 available). Without argument shows available icons.
+/dcrbtnreset
+---> Reset the Decursive button to default: size 44px, icon #1, centered on screen.
+
+TIP: You can also use Shift + Mouse Wheel to resize the button interactively, and Shift + Right Click to cycle through icons.
+
 NOTE that all these commands can be bond to a key.
 
 ACTIONS YOU CAN TAKE:

--- a/localization.es.lua
+++ b/localization.es.lua
@@ -75,15 +75,15 @@ if ( GetLocale() == "esES" or GetLocale() == "esMX" ) then
     DCR_PET_FEL_CAST  = "Devorar magia";
     DCR_PET_DOOM_CAST = "Disipar magia";
 
-    DCR_SPELL_CURE_DISEASE        = 'Curar enfermedad';
-    DCR_SPELL_ABOLISH_DISEASE     = 'Suprimir enfermedad';
+    DCR_SPELL_CURE_DISEASE        = 'Curar Enfermedad';
+    DCR_SPELL_ABOLISH_DISEASE     = 'Suprimir Enfermedad';
     DCR_SPELL_PURIFY              = 'Purificar';
     DCR_SPELL_CLEANSE             = 'Limpiar';
-    DCR_SPELL_DISPELL_MAGIC       = 'Disipar magia';
-    DCR_SPELL_CURE_POISON         = 'Curar veneno';
-    DCR_SPELL_ABOLISH_POISON      = 'Suprimir veneno';
-    DCR_SPELL_REMOVE_LESSER_CURSE = 'Eliminar maldición inferior';
-    DCR_SPELL_REMOVE_CURSE        = 'Eliminar maldición';
+    DCR_SPELL_DISPELL_MAGIC       = 'Disipar Magia';
+    DCR_SPELL_CURE_POISON         = 'Curar Veneno';
+    DCR_SPELL_ABOLISH_POISON      = 'Suprimir Veneno';
+    DCR_SPELL_REMOVE_LESSER_CURSE = 'Eliminar Maldición Inferior';
+    DCR_SPELL_REMOVE_CURSE        = 'Eliminar Maldición';
     DCR_SPELL_PURGE               = 'Purgar';
     DCR_SPELL_RANK_1              = 'Rango 1';
     DCR_SPELL_RANK_2              = 'Rango 2';

--- a/localization.es.lua
+++ b/localization.es.lua
@@ -1,0 +1,188 @@
+--[[
+ Decursive (v 1.9.8) add-on for World of Warcraft UI
+ Copyright (C) 2006 Archarodim ( http://www.2072productions.com/?to=decursive-continued.txt )
+ This is the continued work of the original Decursive (v1.9.4) by Quu
+ Decursive 1.9.4 is in public domain ( www.quutar.com )
+ 
+ License:
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+ 
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+--]]
+
+-------------------------------------------------------------------------------
+-- Spanish localization
+-------------------------------------------------------------------------------
+if ( GetLocale() == "esES" or GetLocale() == "esMX" ) then
+    --start added in Rc4
+    DCR_ALLIANCE_NAME = 'Alianza';
+
+    DCR_LOC_CLASS_DRUID   = 'Druida';
+    DCR_LOC_CLASS_HUNTER  = 'Cazador';
+    DCR_LOC_CLASS_MAGE    = 'Mago';
+    DCR_LOC_CLASS_PALADIN = 'Paladín';
+    DCR_LOC_CLASS_PRIEST  = 'Sacerdote';
+    DCR_LOC_CLASS_ROGUE   = 'Pícaro';
+    DCR_LOC_CLASS_SHAMAN  = 'Chamán';
+    DCR_LOC_CLASS_WARLOCK = 'Brujo';
+    DCR_LOC_CLASS_WARRIOR = 'Guerrero';
+
+    DCR_STR_OTHER	    = 'Otro';
+    DCR_STR_ANCHOR	    = 'Ancla';
+    DCR_STR_OPTIONS	    = 'Opciones de Decursive';
+    DCR_STR_CLOSE	    = 'Cerrar';
+    DCR_STR_ASSISTANT	    = 'Asistente';
+    DCR_STR_DCR_PRIO	    = 'Lista de prioridad';
+    DCR_STR_DCR_SKIP	    = 'Lista de omisiones';
+    DCR_STR_QUICK_POP	    = 'Llenar rápidamente';
+    DCR_STR_POP		    = 'Llenar la lista';
+    DCR_STR_GROUP	    = 'Grupo ';
+
+    DCR_STR_NOMANA	    = '¡No hay suficiente maná!';
+    DCR_STR_UNUSABLE	    = '¡Imposible curar ahora!';
+    DCR_STR_NEED_CURE_ACTION_IN_BARS = "Decursive no pudo encontrar ningún hechizo de curación en tus barras de acción. Lo necesita para verificar el maná...";
+
+    DCR_UP		    = 'ARRIBA';
+    DCR_DOWN		    = 'ABAJO';
+
+    DCR_PRIORITY_SHOW	    = 'P';
+    DCR_POPULATE	    = 'R';
+    DCR_SKIP_SHOW	    = 'S';
+    DCR_ANCHOR_SHOW	    = 'A';
+    DCR_OPTION_SHOW	    = 'O';
+    DCR_CLEAR_PRIO	    = 'L';
+    DCR_CLEAR_SKIP	    = 'L';
+
+    --end added in Rc4
+    DCR_LOC_AF_TYPE [DCR_DISEASE] = 'Enfermedad';
+    DCR_LOC_AF_TYPE [DCR_MAGIC]	  = 'Magia';
+    DCR_LOC_AF_TYPE [DCR_POISON]  = 'Veneno';
+    DCR_LOC_AF_TYPE [DCR_CURSE]	  = 'Maldición';
+    DCR_LOC_AF_TYPE [DCR_CHARMED] = 'Control mental';
+
+    DCR_PET_FELHUNTER = "Manáfago";
+    DCR_PET_DOOMGUARD = "Guardia apocalíptico";
+    DCR_PET_FEL_CAST  = "Devorar magia";
+    DCR_PET_DOOM_CAST = "Disipar magia";
+
+    DCR_SPELL_CURE_DISEASE        = 'Curar enfermedad';
+    DCR_SPELL_ABOLISH_DISEASE     = 'Suprimir enfermedad';
+    DCR_SPELL_PURIFY              = 'Purificar';
+    DCR_SPELL_CLEANSE             = 'Limpiar';
+    DCR_SPELL_DISPELL_MAGIC       = 'Disipar magia';
+    DCR_SPELL_CURE_POISON         = 'Curar veneno';
+    DCR_SPELL_ABOLISH_POISON      = 'Suprimir veneno';
+    DCR_SPELL_REMOVE_LESSER_CURSE = 'Eliminar maldición inferior';
+    DCR_SPELL_REMOVE_CURSE        = 'Eliminar maldición';
+    DCR_SPELL_PURGE               = 'Purgar';
+    DCR_SPELL_RANK_1              = 'Rango 1';
+    DCR_SPELL_RANK_2              = 'Rango 2';
+
+    BINDING_NAME_DCRCLEAN		= "Limpiar grupo";
+    BINDING_NAME_DCRSHOW		= "Mostrar u ocultar la barra principal de Decursive";
+    BINDING_NAME_DCROPTION		= "Mostrar u ocultar la ventana de opciones";
+
+    BINDING_NAME_DCRPRADD		= "Añadir objetivo a la lista de prioridad";
+    BINDING_NAME_DCRPRCLEAR		= "Borrar la lista de prioridad";
+    BINDING_NAME_DCRPRLIST		= "Mostrar la lista de prioridad";
+    BINDING_NAME_DCRPRSHOW		= "Mostrar u ocultar la lista de prioridad";
+
+    BINDING_NAME_DCRSKADD		= "Añadir objetivo a la lista de omisiones";
+    BINDING_NAME_DCRSKCLEAR		= "Borrar la lista de omisiones";
+    BINDING_NAME_DCRSKLIST		= "Mostrar la lista de omisiones";
+    BINDING_NAME_DCRSKSHOW		= "Mostrar u ocultar la lista de omisiones";
+
+    DCR_DISABLE_AUTOSELFCAST	= "Decursive ha detectado que la opción \"%s\" está activada.\n\nDecursive no podrá curar a nadie mientras esta opción esté activa.\n\n¿Deseas desactivarla?";
+
+    DCR_PRIORITY_LIST		= "Lista de prioridad";
+    DCR_SKIP_LIST_STR		= "Lista de omisiones";
+    DCR_SKIP_OPT_STR		= "Menú de opciones";
+    DCR_POPULATE_LIST		= "Llenar rápidamente la lista";
+    DCR_RREMOVE_ID		= "Eliminar este jugador";
+    DCR_HIDE_MAIN		= "Ocultar la ventana \"Decursive\"";
+    DCR_SHOW_MSG		= "Para mostrar la ventana \"Decursive\", escribe /dcrshow.";
+    DCR_IS_HERE_MSG		= "Decursive está iniciado, no olvides revisar las opciones disponibles";
+
+    DCR_PRINT_CHATFRAME		= "Mostrar mensajes en el canal por defecto";
+    DCR_PRINT_CUSTOM		= "Mostrar mensajes en la ventana";
+    DCR_PRINT_ERRORS		= "Mostrar mensajes de error";
+
+    DCR_SHOW_TOOLTIP		= "Mostrar tooltips en la lista de afligidos";
+    DCR_REVERSE_LIVELIST	= "Invertir la visualización de la lista";
+    DCR_HIDE_LIVELIST		= "Ocultar la lista";
+    DCR_TIE_LIVELIST		= "Vincular visibilidad de la lista a \"Decursive\"";
+
+    DCR_AMOUNT_AFFLIC		= "Número de afligidos a mostrar: ";
+    DCR_BLACK_LENGTH		= "Segundos en la lista negra: ";
+    DCR_SCAN_LENGTH		= "Segundos entre escaneos: ";
+    DCR_ABOLISH_CHECK		= "Verificar si \"Suprimir\" está en el objetivo antes de curar";
+    DCR_BEST_SPELL		= "Usar siempre el rango de hechizo más alto";
+    DCR_RANDOM_ORDER		= "Curar aleatoriamente";
+    DCR_CURE_PETS		= "Revisar y curar mascotas";
+    DCR_IGNORE_STEALTH		= "Ignorar unidades en sigilo";
+    DCR_PLAY_SOUND		= "Reproducir sonido cuando haya alguien que curar";
+    DCR_ANCHOR			= "Ancla del texto";
+    DCR_CHECK_RANGE		= "Verificar si el objetivo está en rango";
+    DCR_DONOT_BL_PRIO		= "No poner en lista negra a los prioritarios";
+    DCR_CHOOSE_CURE		= "Curar:";
+
+    -- $s is spell name
+    -- $a is affliction name/type
+    -- $t is target name
+    DCR_DISPELL_ENEMY		= "Lanzando '$s' sobre $t";
+    DCR_NOT_CLEANED		= "¡Nada fue limpiado!";
+    DCR_CLEAN_STRING		= "Disipando \"$a\" de $t";
+    DCR_SPELL_FOUND		= "¡$s encontrado!";
+    DCR_NO_SPELLS		= "¡No se encontraron hechizos de curación!";
+    DCR_NO_SPELLS_RDY		= "¡Ningún hechizo de curación está listo!";
+    DCR_OUT_OF_RANGE		= "¡$t está fuera de rango y necesita ser curado de $a!";
+    DCR_IGNORE_STRING		= "$a encontrado en $t - $t ignorado.";
+
+    DCR_INVISIBLE_LIST = {
+	["Acechar"]			= true,
+	["Sigilo"]			= true,
+	["Acechar en las sombras"]	= true,
+    }
+
+    DCR_IGNORELIST = {
+	["Desterrar"]			= true,
+	["Cambio de fase"]		= true,
+    };
+
+    DCR_SKIP_LIST = {
+	["Sueño sin sueños"]		= true,
+	["Sueño sin sueños mayor"]	= true,
+	["Visión telepática"]		= true,
+	["Inyección mutante"]		= true,
+    };
+
+    DCR_SKIP_BY_CLASS_LIST = {
+	[DCR_CLASS_WARRIOR] = {
+	    ["Histeria ancestral"]	= true,
+	    ["Inflamar maná"]		= true,
+	    ["Espíritu corrupto"]	= true,
+	};
+	[DCR_CLASS_ROGUE] = {
+	    ["Silencio"]		= true;
+	    ["Histeria ancestral"]	= true,
+	    ["Inflamar maná"]		= true,
+	    ["Espíritu corrupto"]	= true,
+	};
+	[DCR_CLASS_HUNTER] = {
+	    ["Grilletes de magma"]	= true,
+	};
+	[DCR_CLASS_MAGE] = {
+	    ["Grilletes de magma"]	= true,
+	};
+    };
+end


### PR DESCRIPTION
## Summary
Adds a new slash command to reset the Decursive button and documents all button-related commands in README files.

## Changes
- **New command `/dcrbtnreset`**: Resets the button to default state (44px size, icon #1, centered on screen)
- **Updated documentation** in `README.md` and `Readme.txt` with a dedicated section for button commands

## Button Commands
| Command | Description |
|---------|-------------|
| `/dcrsize <size>` | Set button size (20-100px) |
| `/dcricon <number>` | Change button icon (1-12) |
| `/dcrbtnreset` | Reset button to defaults |

## Tips
- Shift + Mouse Wheel to resize interactively
- Shift + Right Click to cycle through icons